### PR TITLE
feature: structure for individual product page

### DIFF
--- a/src/components/product/add.tsx
+++ b/src/components/product/add.tsx
@@ -1,0 +1,15 @@
+type AddProps = {
+    placeholder?: string;
+  };
+  
+  function Add({ placeholder }: AddProps) {
+    return (
+        <button className="bg-white text-[#D21706] py-3 px-4 border-4 border-[#D21706] rounded w-full font-bold">
+        {placeholder}
+      </button>
+      
+    );
+  }
+  
+  export {Add };
+  

--- a/src/components/product/back.tsx
+++ b/src/components/product/back.tsx
@@ -1,0 +1,23 @@
+import { Url } from 'next/dist/shared/lib/router/router';
+import Link from 'next/link';
+
+type BackProps = {
+    placeholder?: string;
+    ref?: Url;
+
+};
+
+
+function Back({ placeholder,ref }: BackProps) {
+  return (
+    <Link
+      href={ref || '/'}
+      className="text-black font-[Inter] text-base font-bold"
+    >
+      {placeholder}
+      
+    </Link>
+  );
+}
+
+export {Back}

--- a/src/components/product/purchase.tsx
+++ b/src/components/product/purchase.tsx
@@ -1,0 +1,14 @@
+type PurchaseNowProps = {
+    placeholder?: string;
+  };
+  
+  function PurchaseNow({ placeholder }: PurchaseNowProps) {
+    return (
+      <button className="bg-[#D21706] text-white py-3 px-4 rounded w-full font-bold">
+        {placeholder}
+      </button>
+    );
+  }
+  
+  export {PurchaseNow };
+  

--- a/src/components/shared/Img/index.tsx
+++ b/src/components/shared/Img/index.tsx
@@ -14,7 +14,7 @@ function Img({ source, placeholder, w, h}: ImgProps) {
       alt={placeholder || 'Image'}
       width={w}
       height={h}
-      className="object-cover w-36 h-36"
+      className="object-cover"
     />
   );
 }

--- a/src/pages/product-list/index.tsx
+++ b/src/pages/product-list/index.tsx
@@ -2,7 +2,6 @@ import { Container } from "@/components/shared/Container";
 import { Img } from "@/components/shared/Img";
 import { PurchaseButton } from "@/components/product-list/purchasebtn";
 import { AddToCart } from "@/components/product-list/addtocart";
-import { Navbar } from "@/components/shared/Navbar/Navbar";
 import placeholderimage from "@/assets/placeholderimg.png";
 
 export default function ProductList() {

--- a/src/pages/product/index.tsx
+++ b/src/pages/product/index.tsx
@@ -1,0 +1,39 @@
+import { Container } from "@/components/shared/Container";
+import { Back } from "@/components/product/back";
+import { Img } from "@/components/shared/Img";
+import { PurchaseNow } from "@/components/product/purchase";
+import { Add } from "@/components/product/add";
+import placeholderimage from "@/assets/placeholderimg.png";
+
+
+export default function Product(){
+    return(
+        <Container>
+        <div className="flex flex-col items-center justify-center p-4">
+            <div>
+                <div className="flex items-left justify-start pb-1 p-4">
+                    <Back placeholder="Back" ref="/product-list" />
+                </div>
+                <div className="flex flex-col items-center justify-center p-4  gap-4 ">
+                 <Img source={placeholderimage.src} w={308} h={283} />
+                 <div className="flex flex-row justify-between w-full pt-2 pb-2"> 
+                    <p className="text-xl text-[#111827] font-[Inter] font-bold">Product Name</p>
+                    <p className="text-xl text-[#4B5563] font-[Inter] font-light">$ 0.00</p>
+                 </div>
+                 <PurchaseNow placeholder="Purchase Now" />
+                 <Add placeholder="Add to Cart" />
+                 <div className="flex flex-col items-left justify-start gap-2">
+                 <p className="text-xl text-[#111827] font-[Inter] font-bold">About Product</p>
+                 <p className="text-xl text-[#4B5563] font-[Inter] font-light">
+                    Adipiscing elit ac lobortis turpis quam. Sit venenatis mollis id libero. 
+                    Fermentum quis est, in consectetur nulla purus augue.
+                 </p>
+                 </div>
+
+                </div>
+
+            </div>
+         </div>
+        </Container>
+    );
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -63,7 +63,6 @@ svg {
 
 /* 7. Inherit fonts for form controls */
 input,
-button,
 textarea,
 select {
   font: inherit;


### PR DESCRIPTION
On this pull request, I added components for the individual product page:
 - Add to cart button (product page version)
 - Purchase button (product page version)
 - Back to list link 
 I also used components from the shared folder, such as image and container. It was necessary to modify the global.css file because the inherit property was not allowing me to put bold text on the buttons, which exists on the figma file.

![image](https://github.com/user-attachments/assets/f35c869a-1f5a-4319-b22d-5cc7b47e5f0e)

IMPORTANT: everything in this page is mocked. It's likely we'll have to create something like /[id] to fetch data from the api later, however, right now there's only the structure (components) and mocked data