### PR TITLE
feature: structure for orders UI

### DIFF
--- a/src/pages/orders/index.tsx
+++ b/src/pages/orders/index.tsx
@@ -1,0 +1,45 @@
+import { LeftContainer } from "@/components/shared/LeftContainer";
+import { Container } from "@/components/shared/Container";
+import { FlexContainer } from "@/components/shared/FlexContainer";
+import { Img } from "@/components/shared/Img";
+import placeholderimage from "@/assets/placeholderimg.png";
+import { PurchaseNow } from "@/components/product/purchase";
+
+
+export default function Orders(){
+    return(
+        <div className="p-2">
+              <LeftContainer>
+                <p className="text-3xl text-[#111827] font-[Inter] font-bold pt-2">Orders</p>
+              </LeftContainer>
+              <Container>
+                <FlexContainer>
+                <p className="text-sm text-[#4B5563] font-[Inter] font-light">Order 4616e4d4-9183-40c8-a880-b633cd86fa21</p>
+                    <Container>
+
+                    <div className="flex flex-row justify-evenly place-items-center p-2 gap-4">
+                        <Img source={placeholderimage.src} w={147} h={124} />   
+                        <Container>
+                        <p className="text-xl text-[#111827] font-[Inter] font-bold">Product 1 Name</p>
+                        <p className="text-base text-[#4B5563] font-[Inter] font-light">$ 0.00</p>
+                        <p className="text-base text-[#4B5563] font-[Inter] font-light">Quantity: 2</p>
+                        </Container>
+                    </div>
+
+                    <div className="flex flex-row justify-evenly place-items-center p-2 gap-4">
+                        <Img source={placeholderimage.src} w={147} h={124} />   
+                        <Container>
+                        <p className="text-xl text-[#111827] font-[Inter] font-bold">Product 2 Name</p>
+                        <p className="text-base text-[#4B5563] font-[Inter] font-light">$ 0.00</p>
+                        <p className="text-base text-[#4B5563] font-[Inter] font-light">Quantity: 1 </p>
+                        </Container>
+                    </div>
+                    
+                    <PurchaseNow placeholder="Purchase again"/>
+                    </Container>
+                </FlexContainer>
+              </Container>
+
+        </div>
+    );
+}


### PR DESCRIPTION
This is the Orders page UI. Despite the figma file having two orders, I only mocked one because, in my opinion, it will be easier to remove the mocks when the time to connect this UI to the real API comes. So it looks like this

![image](https://github.com/user-attachments/assets/e85aac22-9e82-4974-b54a-8c326ef0f8b7)

It's pretty on point on the figma file, but only with the first order. No new components were needed.