### PR TITLE
refactor: confirmation message and continue shopping button

### DIFF
--- a/src/components/product/add.tsx
+++ b/src/components/product/add.tsx
@@ -4,7 +4,7 @@ type AddProps = {
   
   function Add({ placeholder }: AddProps) {
     return (
-        <button className="bg-white text-[#D21706] py-3 px-4 border-4 border-[#D21706] rounded w-full font-bold">
+        <button className="bg-white text-[#D21706] py-3 px-4 border-4 border-[#D21706] text-center rounded w-full font-bold">
         {placeholder}
       </button>
       

--- a/src/components/shared/LinkButton/index.tsx
+++ b/src/components/shared/LinkButton/index.tsx
@@ -1,0 +1,23 @@
+import { Url } from 'next/dist/shared/lib/router/router';
+import Link from 'next/link';
+
+type LinkButtonProps = {
+    placeholder?: string;
+    ref?: Url;
+
+};
+
+
+function LinkButton({ placeholder,ref }: LinkButtonProps) {
+  return (
+    <Link
+    href={ref || '/'}
+    className="flex justify-center items-center bg-white text-[#D21706] py-3 px-4 border-4 border-[#D21706] rounded w-full font-bold"
+    >
+    {placeholder}
+    </Link>
+
+  );
+}
+
+export {LinkButton}

--- a/src/pages/checkout/confirmation/index.tsx
+++ b/src/pages/checkout/confirmation/index.tsx
@@ -1,7 +1,7 @@
 import { Container } from "@/components/shared/Container";
 import { FlexContainer } from "@/components/shared/FlexContainer";
 import { Img } from "@/components/shared/Img";
-import { Add } from "@/components/product/add";
+import { LinkButton } from "@/components/shared/LinkButton";
 import placeholderimage from "@/assets/placeholderimg.png";
 
 export default function Confirmation(){
@@ -12,11 +12,11 @@ export default function Confirmation(){
                 <FlexContainer> 
                     <p className="text-3xl text-[#111827] font-[Inter] font-bold pt-2">Thanks for shopping!</p>
                     <p className="text-xl text-[#4B5563] font-[Inter] font-light p-2 pb-4">
-                    Netus ultricies duis sed vulputate egestas pretium ac proin ullamcorper.
-                    Ullamcorper mauris ultrices duis volutpat consequat ultrices tempor ultrices. 
-                    Tellus ut nulla ut placerat in.
+                        Your order has been received and is being processed. You will receive a confirmation email shortly.
+                        Thanks for trusting us with your purchase, you're always welcome back!
+                    
                  </p>
-                    <Add placeholder="Continue Shopping" />
+                    <LinkButton ref="/products" placeholder="Continue Shopping" />
                 </FlexContainer>
             </FlexContainer>
         </Container>


### PR DESCRIPTION
Removed the lorem ipsum text and added a "purchase finished" message instead. Also, new component added: LinkButton. It basically looks like a button but it's an <a> (Link on react/nextJS), since the "continue shopping"  button should be a navigation to the '/products' route  (so you can actually continue shopping XD )and <a> is more appropriate for navigation than a button. (just trying to adhere to good pratices). So now instead of the <button> we have:

```
import { Url } from 'next/dist/shared/lib/router/router';
import Link from 'next/link';

type LinkButtonProps = {
    placeholder?: string;
    ref?: Url;

};


function LinkButton({ placeholder,ref }: LinkButtonProps) {
  return (
    <Link
    href={ref || '/'}
    className="flex justify-center items-center bg-white text-[#D21706] py-3 px-4 border-4 border-[#D21706] rounded w-full font-bold"
    >
    {placeholder}
    </Link>

  );
}

export {LinkButton}

```

and here is how it looks on the page code

```
 <LinkButton ref="/products" placeholder="Continue Shopping" />
```